### PR TITLE
Remove obj info arr

### DIFF
--- a/Don't_push/Don't_push/Don't_push.vcxproj
+++ b/Don't_push/Don't_push/Don't_push.vcxproj
@@ -60,7 +60,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>CTP_Nov2013</PlatformToolset>
+    <PlatformToolset>v120</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='VS2015Debug|Win32'" Label="Configuration">
@@ -72,7 +72,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>CTP_Nov2013</PlatformToolset>
+    <PlatformToolset>v120</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
@@ -98,7 +98,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>CTP_Nov2013</PlatformToolset>
+    <PlatformToolset>v120</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>

--- a/Don't_push/Don't_push/source/circular_motion.cpp
+++ b/Don't_push/Don't_push/source/circular_motion.cpp
@@ -7,12 +7,19 @@ obj_info::obj_info(const dxle::pointi& first_p, const DxGHandle* img_normal, con
 	this->m_screen_.DrawnOn([this]() {this->m_img_[0]->DrawExtendGraph({}, { this->m_img_[0]->GetGraphSize().x / 3, this->m_img_[0]->GetGraphSize().y / 3 }, true); });
 }
 
+obj_info::obj_info(obj_info&& o) NOEXCEPT
+	: m_first_pos_(o.m_first_pos_), m_p_(o.m_p_), m_img_(o.m_img_),
+	m_screen_(std::move(o.m_screen_)), m_current_img_no_(o.m_current_img_no_)
+{}
+
 dxle::pointi obj_info::calc_first_bottom_right_pos() const NOEXCEPT {
-	return this->m_p_ + this->m_screen_.GetGraphSize();
+	auto re = this->m_p_ + this->m_screen_.GetGraphSize();
+	return re;
 }
 
 dxle::pointi obj_info::distance_from_first() const NOEXCEPT {
-	return this->m_first_pos_ - this->m_p_;
+	auto re = this->m_first_pos_ - this->m_p_;
+	return re;
 }
 
 void obj_info::change_img(int no) NOEXCEPT {

--- a/Don't_push/Don't_push/source/circular_motion.h
+++ b/Don't_push/Don't_push/source/circular_motion.h
@@ -9,6 +9,10 @@ class obj_info
 {
 public:
 	obj_info(const dxle::pointi& first_p, const DxGHandle* img_normal, const DxGHandle* img_fall);
+	obj_info(const obj_info& o) = delete;
+	obj_info(obj_info&& o) NOEXCEPT;
+	obj_info& operator=(const obj_info&) = delete;
+	obj_info& operator=(obj_info&&) = delete;
 	void change_img(int no = -1) NOEXCEPT;
 	bool draw(bool Trans_flag = true) const NOEXCEPT;
 	void state_init() NOEXCEPT;

--- a/Don't_push/Don't_push/source/continue.cpp
+++ b/Don't_push/Don't_push/source/continue.cpp
@@ -15,7 +15,7 @@ Status continu(const img_arr_t&, const sound_arr_t& sound) {
 	DXLE_STATIC_CONSTEXPR int select1_x = 260;
 	DXLE_STATIC_CONSTEXPR int select1_y = 250;
 
-	const std::array<unsigned int, 2>color = { GetColor(0,0,0), GetColor(255,255,255) };//選択している, 選択していない
+	const std::array<unsigned int, 2>color = { { GetColor(0,0,0), GetColor(255,255,255) } };//選択している, 選択していない
 	bool flag_no_continue = false;		//コンティニューするかどうか
 
 	//メインループ

--- a/Don't_push/Don't_push/source/game.cpp
+++ b/Don't_push/Don't_push/source/game.cpp
@@ -9,18 +9,16 @@
 #include "power_bar.h"
 #include "circular_motion.h"
 #include <cmath>
-#include <array>
 #include <algorithm>
 #include <deque>
+#include <tuple>
 
 struct game_c::Impl {
 	Impl(const dxle::pointi& bouninngennA_p, const dxle::pointi& bouninngennB_p)
 		: m_window_s(static_cast<int>(WINDOW_WIDTH), static_cast<int>(WINDOW_HEIGHT)), m_state(), m_back_img(dxle::Graph2D::MakeScreen(m_window_s.x, m_window_s.y)),
 		m_img(make_image_array()), m_sound(make_sound_array()), score(),
-		m_bouninngenn({ {
-			{ bouninngennA_p, &m_img["bouninngennA"], &m_img["bouninngennA_fall"]},//棒人形A
-			{ bouninngennB_p, &m_img["bouninngennB"], &m_img["bouninngennB_fall"]} //棒人形B
-		} })
+		m_bouninngenn_a{ bouninngennA_p, &m_img["bouninngennA"], &m_img["bouninngennA_fall"] },//棒人形A
+		m_bouninngenn_b{ bouninngennB_p, &m_img["bouninngennB"], &m_img["bouninngennB_fall"] } //棒人形B
 	{
 		this->m_back_img.DrawnOn([this]() {m_img["gake"].DrawExtendGraph({}, m_window_s, false); });
 	}
@@ -33,13 +31,15 @@ struct game_c::Impl {
 	void move_x(int limit_l_x, int limit_r_x) NOEXCEPT;
 	void fadeout_prelude_masseage();
 	template<std::size_t bouninngenn_no> void fall_bouninngenn(const std::deque<dxle::pointi>& pos_record);
+	bool bouninngen_draw() const NOEXCEPT;
 	const dxle::pointi m_window_s;
 	keystate m_state;
 	dxle::Graph2D::screen m_back_img;
 	img_arr_t m_img;
 	sound_arr_t m_sound;
 	std::uint8_t score;//0-100
-	std::array<obj_info, 2>m_bouninngenn;
+	obj_info m_bouninngenn_a;
+	obj_info m_bouninngenn_b;
 };
 game_c::game_c(const dxle::pointi& bouninngennA_p, const dxle::pointi& bouninngennB_p) : pimpl(new game_c::Impl(bouninngennA_p, bouninngennB_p)){}
 
@@ -61,9 +61,9 @@ void game_c::Impl::move_x(int limit_l_x, int limit_r_x) NOEXCEPT{
 	if (limit_r_x < limit_l_x) std::swap(limit_l_x, limit_r_x);
 	DXLE_STATIC_CONSTEXPR int CHARACTER_MOVE_SPEED = 4;
 	this->m_state.update();
-	if (this->m_state.left()) this->m_bouninngenn[1].get_pos().x -= CHARACTER_MOVE_SPEED;
-	if (this->m_state.right()) this->m_bouninngenn[1].get_pos().x += CHARACTER_MOVE_SPEED;
-	this->m_bouninngenn[1].get_pos().x = std::min(limit_r_x, std::max(this->m_bouninngenn[1].get_pos().x, limit_l_x));
+	if (this->m_state.left()) this->m_bouninngenn_b.get_pos().x -= CHARACTER_MOVE_SPEED;
+	if (this->m_state.right()) this->m_bouninngenn_b.get_pos().x += CHARACTER_MOVE_SPEED;
+	this->m_bouninngenn_b.get_pos().x = std::min(limit_r_x, std::max(this->m_bouninngenn_b.get_pos().x, limit_l_x));
 }
 
 #ifdef _MSC_VER
@@ -72,7 +72,7 @@ void game_c::Impl::move_x(int limit_l_x, int limit_r_x) NOEXCEPT{
 #endif
 void game_c::Impl::state_init() NOEXCEPT {
 	this->m_state.fllush();
-	for (auto& i : this->m_bouninngenn) i.state_init();
+	this->bouninngen_draw();
 	this->score = 0;
 }
 void game_c::Impl::fadeout_prelude_masseage() {
@@ -85,9 +85,14 @@ void game_c::Impl::fadeout_prelude_masseage() {
 		SetDrawBlendMode(DX_BLENDMODE_ALPHA, static_cast<int>((fadeout_time_frame - i) * 256.0 / fadeout_time_frame));
 		this->m_img["back_str"].DrawGraph({}, true);
 		SetDrawBlendMode(DX_BLENDMODE_NOBLEND, 0);
-		for (auto& im : this->m_bouninngenn) im.draw();
+		this->bouninngen_draw();
 	}
 	if (m_state.esc()) throw normal_exit();
+}
+
+bool game_c::Impl::bouninngen_draw() const NOEXCEPT
+{
+	return m_bouninngenn_a.draw() && m_bouninngenn_b.draw();;
 }
 
 static int calc_free_fall(int y, size_t t) ATT_PURE {
@@ -111,9 +116,9 @@ template<std::size_t bouninngenn_no> void game_c::Impl::fall_bouninngenn(const s
 	}();
 	bool is_normal_state = true;
 	while ((is_normal_state = this->normal_con_f()) && this->m_state.update() && !this->m_state.esc()) {
-		this->m_bouninngenn[bouninngenn_no].get_pos().x -= v;
+		std::get<bouninngenn_no>(std::tie(this->m_bouninngenn_a, this->m_bouninngenn_b)).get_pos().x -= v;
 		this->m_back_img.DrawGraph({}, false);
-		for (auto& i : this->m_bouninngenn) i.draw();
+		this->bouninngen_draw();
 	}
 	if (!is_normal_state) throw std::runtime_error("ProcessMessage() return -1.");
 	if (this->m_state.esc()) throw normal_exit();
@@ -139,11 +144,11 @@ Status game_c::game_main() {
 	bool is_normal_state = true;
 	while ((is_normal_state = this->pimpl->normal_con_f()) && this->pimpl->m_state.update() && !this->pimpl->m_state[KEY_INPUT_Z] && !this->pimpl->m_state.esc()) {
 		power_bar.update();
-		this->pimpl->move_x(this->pimpl->m_bouninngenn[0].calc_first_bottom_right_pos().x, this->pimpl->m_bouninngenn[1].get_fitst_pos().x);
+		this->pimpl->move_x(this->pimpl->m_bouninngenn_a.calc_first_bottom_right_pos().x, this->pimpl->m_bouninngenn_b.get_fitst_pos().x);
 		if (4 < pos_record.size()) pos_record.pop_front();
-		pos_record.push_back(this->pimpl->m_bouninngenn[1].get_pos());
+		pos_record.push_back(this->pimpl->m_bouninngenn_b.get_pos());
 		this->pimpl->m_back_img.DrawGraph({}, false);
-		for (auto& i : this->pimpl->m_bouninngenn) i.draw();
+		this->pimpl->bouninngen_draw();
 		const dxle::pointi gauge_bg_p = { WINDOW_WIDTH / 2, WINDOW_HEIGHT * 5 / 6 };
 		this->pimpl->m_img["game_main_gauge_bg"].DrawExtendGraph(gauge_bg_p, gauge_bg_p + dxle::pointi{ WINDOW_WIDTH * 7 / 16, WINDOW_HEIGHT * 7 / 60 }, false);
 		power_bar.draw();
@@ -151,8 +156,8 @@ Status game_c::game_main() {
 	if (!is_normal_state) throw std::runtime_error("ProcessMessage() return -1.");
 	if (this->pimpl->m_state.esc()) throw normal_exit();
 
-	const int d = distance(this->pimpl->m_bouninngenn[0], this->pimpl->m_bouninngenn[1]);
-	const auto rate = bouninngenn_moving_distance(this->pimpl->m_bouninngenn[0], this->pimpl->m_bouninngenn[1]);
+	const int d = distance(this->pimpl->m_bouninngenn_a, this->pimpl->m_bouninngenn_b);
+	const auto rate = bouninngenn_moving_distance(this->pimpl->m_bouninngenn_a, this->pimpl->m_bouninngenn_b);
 	const auto p_rate = power_bar.get_percent();
 	bool is_game_over = false;
 	if (d < 0 || rate < 80.0 || p_rate < 60.0) {
@@ -202,12 +207,12 @@ Status game_c::helicopter_event() {
 	bool is_normal_state = true;
 	while ((is_normal_state = this->pimpl->normal_con_f()) && pimpl->m_state.update() && !pimpl->m_state[KEY_INPUT_Z] && !pimpl->m_state.esc() && helicopter.update()) {
 		this->pimpl->m_back_img.DrawGraph({}, false);
-		extruder(this->pimpl->m_bouninngenn[1], helicopter.get_obj());
-		extruder(this->pimpl->m_bouninngenn[0], this->pimpl->m_bouninngenn[1]);
-		for (auto& i : this->pimpl->m_bouninngenn) i.draw();
+		extruder(this->pimpl->m_bouninngenn_b, helicopter.get_obj());
+		extruder(this->pimpl->m_bouninngenn_a, this->pimpl->m_bouninngenn_b);
+		this->pimpl->bouninngen_draw();
 		helicopter.draw();
 		//WaitKey();
-		if (std::all_of(this->pimpl->m_bouninngenn.begin(), this->pimpl->m_bouninngenn.end(), [](const obj_info& a) -> bool { return a.is_fallen(); }))break;//ふたりとも落ちたらゲーム終わり
+		if (this->pimpl->m_bouninngenn_a.is_fallen() && this->pimpl->m_bouninngenn_b.is_fallen()) break;//ふたりとも落ちたらゲーム終わり
 	}
 	if (!is_normal_state) throw std::runtime_error("ProcessMessage() return -1.");
 	if (pimpl->m_state.esc()) throw normal_exit();

--- a/Don't_push/Don't_push/source/game.cpp
+++ b/Don't_push/Don't_push/source/game.cpp
@@ -13,29 +13,32 @@
 #include <algorithm>
 #include <deque>
 
-
 struct game_c::Impl {
 	Impl(const dxle::pointi& bouninngennA_p, const dxle::pointi& bouninngennB_p)
 		: m_window_s(static_cast<int>(WINDOW_WIDTH), static_cast<int>(WINDOW_HEIGHT)), m_state(), m_back_img(dxle::Graph2D::MakeScreen(m_window_s.x, m_window_s.y)),
 		m_img(make_image_array()), m_sound(make_sound_array()), score(),
-		m_bouninngenn{ {
+		m_bouninngenn({ {
 			{ bouninngennA_p, &m_img["bouninngennA"], &m_img["bouninngennA_fall"]},//棒人形A
 			{ bouninngennB_p, &m_img["bouninngennB"], &m_img["bouninngennB_fall"]} //棒人形B
-		} }
+		} })
 	{
 		this->m_back_img.DrawnOn([this]() {m_img["gake"].DrawExtendGraph({}, m_window_s, false); });
 	}
+	Impl(const Impl&) = delete;
+	Impl(Impl&&) = delete;
+	Impl& operator=(const Impl&) = delete;
+	Impl& operator=(Impl&&) = delete;
 	void state_init() NOEXCEPT;
 	bool normal_con_f() const NOEXCEPT;
 	void move_x(int limit_l_x, int limit_r_x) NOEXCEPT;
 	void fadeout_prelude_masseage();
-	void fall_bouninngenn(size_t bouninngenn_no, const std::deque<dxle::pointi>& pos_record);
+	template<std::size_t bouninngenn_no> void fall_bouninngenn(const std::deque<dxle::pointi>& pos_record);
 	const dxle::pointi m_window_s;
 	keystate m_state;
 	dxle::Graph2D::screen m_back_img;
 	img_arr_t m_img;
 	sound_arr_t m_sound;
-	uint8_t score;//0-100
+	std::uint8_t score;//0-100
 	std::array<obj_info, 2>m_bouninngenn;
 };
 game_c::game_c(const dxle::pointi& bouninngennA_p, const dxle::pointi& bouninngennB_p) : pimpl(new game_c::Impl(bouninngennA_p, bouninngennB_p)){}
@@ -92,7 +95,7 @@ static int calc_free_fall(int y, size_t t) ATT_PURE {
 	DXLE_STATIC_CONSTEXPR double correction_factor = 10.5;
 	return y + static_cast<int>(correction_factor * g / 2 * t);
 }
-void game_c::Impl::fall_bouninngenn(size_t bouninngenn_no, const std::deque<dxle::pointi>& pos_record) {
+template<std::size_t bouninngenn_no> void game_c::Impl::fall_bouninngenn(const std::deque<dxle::pointi>& pos_record) {
 	const int v = [&pos_record]() -> int {
 		if (pos_record.size() < 2) return 10;
 		int64_t sum = 0;
@@ -123,9 +126,9 @@ void game_c::Impl::fall_bouninngenn(size_t bouninngenn_no, const std::deque<dxle
 #pragma warning (disable: 4706) //warning C4706: 条件式の比較値は、代入の結果になっています。
 #endif
 
-static double bouninngenn_moving_distance(const std::array<obj_info, 2>& bouninngenn) {
-	const auto denominator = std::abs(distance_first(bouninngenn[0], bouninngenn[1]));
-	return std::abs(denominator - bouninngenn[1].distance_from_first().x) * 100.0 / denominator;
+static double bouninngenn_moving_distance(const obj_info& bouninngenn_a, const obj_info& bouninngenn_b) {
+	const auto denominator = std::abs(distance_first(bouninngenn_a, bouninngenn_b));
+	return std::abs(denominator - bouninngenn_b.distance_from_first().x) * 100.0 / denominator;
 }
 Status game_c::game_main() {
 	this->pimpl->state_init();//状態初期化
@@ -149,21 +152,21 @@ Status game_c::game_main() {
 	if (this->pimpl->m_state.esc()) throw normal_exit();
 
 	const int d = distance(this->pimpl->m_bouninngenn[0], this->pimpl->m_bouninngenn[1]);
-	const auto rate = bouninngenn_moving_distance(this->pimpl->m_bouninngenn);
+	const auto rate = bouninngenn_moving_distance(this->pimpl->m_bouninngenn[0], this->pimpl->m_bouninngenn[1]);
 	const auto p_rate = power_bar.get_percent();
 	bool is_game_over = false;
 	if (d < 0 || rate < 80.0 || p_rate < 60.0) {
-		this->pimpl->fall_bouninngenn(1, pos_record);//落とそうとして落とされる、ゲームオーバー
+		this->pimpl->fall_bouninngenn<1>(pos_record);//落とそうとして落とされる、ゲームオーバー
 		is_game_over = true;
 	}
 	else {
 		this->pimpl->score = static_cast<uint8_t>((p_rate + rate) / 2);//0-100
 		if (this->pimpl->score < 40) {
-			this->pimpl->fall_bouninngenn(1, pos_record);//落とそうとして落とされる、ゲームオーバー
+			this->pimpl->fall_bouninngenn<1>(pos_record);//落とそうとして落とされる、ゲームオーバー
 			is_game_over = true;
 		}
 		else {
-			this->pimpl->fall_bouninngenn(0, pos_record);//落とす。成功！
+			this->pimpl->fall_bouninngenn<0>(pos_record);//落とす。成功！
 		}
 	}
 	return (is_game_over) ? Status::GAME_OVER : Status::RESULT_ECHO;

--- a/Don't_push/Don't_push/source/game.h
+++ b/Don't_push/Don't_push/source/game.h
@@ -11,6 +11,8 @@ public:
 	~game_c();
 	game_c(const game_c&) = delete;
 	game_c(game_c&&) = delete;
+	game_c& operator=(const game_c&) = delete;
+	game_c& operator=(game_c&&) = delete;
 	const img_arr_t& get_img() const NOEXCEPT;
 	const sound_arr_t& get_sound() const NOEXCEPT;
 


### PR DESCRIPTION
```
1>..\..\Don't_push\Don't_push\source\game.cpp(40): error C2280: 'dxle::Graph2D::screen::screen(const dxle::Graph2D::screen &)' : 削除された関数を参照しようとしています
1>          C:\Users\j.pierreno\Documents\git\DxLibEx\dxlibex/Graph2D.h(324) : 'dxle::Graph2D::screen::screen' の宣言を確認してください。
1>          コンパイラでのこの診断により関数 'obj_info::obj_info(const obj_info &)' が生成されました。
```

Visual Studio 2013 Update 5でのこのようなコンパイルエラー除去のために、``std::array``の使用をやめた